### PR TITLE
프로필 수정 > 닉네임 및 마케팅 수신동의 api 연동

### DIFF
--- a/src/api/user.js
+++ b/src/api/user.js
@@ -1,0 +1,48 @@
+import api from '@/lib/api';
+
+export const userApi = {
+  async getMe() {
+    const { data } = await api.get('/api/v1/member/me');
+    return data;
+  },
+
+  async getProfile() {
+    const { data } = await api.get('/api/v1/member/profile');
+    return data;
+  },
+
+  async logout() {
+    await api.post('/api/v1/auth/logout');
+  },
+
+  async getNotifications({ page = 0, size = 10, hours = 48 } = {}) {
+    const { data } = await api.get('/api/v1/users/notifications', {
+      params: { page, size, hours },
+    });
+    return data;
+  },
+
+  async getMyBoards({ page = 0, size = 10 } = {}) {
+    const { data } = await api.get('/api/v1/boards/my', {
+      params: { page, size },
+    });
+    return data;
+  },
+
+  async getMyComments({ page = 0, size = 10 } = {}) {
+    const { data } = await api.get('/api/v1/comments/my', {
+      params: { page, size },
+    });
+    return data;
+  },
+
+  async toggleMarketingAgreement() {
+    const { data } = await api.put('/api/v1/member/marketing-agreement');
+    return data;
+  },
+
+  async updateNickname(nickname) {
+    const { data } = await api.put('/api/v1/member/nickname', { nickname });
+    return data;
+  },
+};


### PR DESCRIPTION
- 초기 사용자 닉네임 정보 조회 api 연동
  - 프로필 정보 불러오기 에러 케이스 alert 처리
- 닉네임 변경 api 연동
  - 에러 케이스 alert 처리
- 마케팅 수신 동의 연동
  - 에러 케이스 alert 처리



-> 수정완료 클릭시 닉네임 및 마케팅 수신 동의 토글에서 변화가 있는 것만 감지해서 해당 api 호출
-> 수정 완료 성공 케이스 alert 처리