### PR TITLE
커뮤니티 패널에서 최신 게시글, 조회수 높은 게시글 불러오기 및 클릭시 상세 패널 오픈

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -37,11 +37,13 @@ body,
   padding: 0;
   box-sizing: border-box;
 }
+
 button {
   background-color: transparent;
   border: none;
   cursor: pointer;
 }
+
 a,
 img,
 fieldset {
@@ -50,11 +52,13 @@ fieldset {
   outline: 1;
   border: none;
 }
+
 ul,
 ol,
 li {
   list-style: none;
 }
+
 textarea {
   resize: none;
 }
@@ -71,7 +75,8 @@ mark {
 /* 한 줄 생략 (...) */
 .ellipsis__1 {
   display: -webkit-box !important;
-  -webkit-line-clamp: 1; /* 줄 수를 여기서 조절 */
+  -webkit-line-clamp: 1;
+  /* 줄 수를 여기서 조절 */
   -webkit-box-orient: vertical;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -80,10 +85,11 @@ mark {
 /* 여러 줄 생략 (...) — 기본 두 줄 */
 .ellipsis__2 {
   display: -webkit-box !important;
-  -webkit-line-clamp: 2; /* 줄 수를 여기서 조절 */
+  -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
   overflow: hidden;
   text-overflow: ellipsis;
+  word-break: break-word;
 }
 
 /* scroll reset 전역 커스텀 스크롤 */
@@ -97,22 +103,27 @@ mark {
   padding: 24px 0;
   padding-right: 6px;
 }
+
 /* 스크롤바 막대 설정*/
 .scroll_area::-webkit-scrollbar {
   width: 10px;
   height: 10px;
 }
+
 .scroll_area::-webkit-scrollbar:hover {
   width: 10px;
   height: 10px;
 }
+
 .scroll_area::-webkit-scrollbar-button {
   display: none;
 }
+
 .scroll_area::-webkit-scrollbar-thumb {
   background-color: #ffefeb;
   border-radius: 6px;
 }
+
 /* 스크롤바 뒷 배경 설정*/
 .scroll_area::-webkit-scrollbar-track {
   background-color: rgba(255, 239, 235, 0.65);

--- a/src/components/CommunityPopup.vue
+++ b/src/components/CommunityPopup.vue
@@ -72,7 +72,7 @@
               <span>다크플레이스 등록</span>
               <span class="point_color">{{
                 auth.approvedReportCount ?? 0
-                }}</span>
+              }}</span>
             </li>
           </ul>
           <p class="tap_count_info" v-if="currentTab === '내 게시글'">
@@ -131,7 +131,7 @@
                   </span>
                   <span class="ellipsis__2 alarm_contents">{{
                     item.title
-                  }}</span>
+                    }}</span>
                 </button>
               </li>
             </template>
@@ -149,7 +149,7 @@
                   </span>
                   <span class="ellipsis__2 alarm_contents">{{
                     item.comment
-                  }}</span>
+                    }}</span>
                 </button>
               </li>
             </template>
@@ -168,7 +168,7 @@
           </p>
           <!-- 게시글 슬라이더 -->
           <div class="BaseCommunity__card">
-            <CarouselWrap :onCardClick="(card) => handleCarouselClick(card)" />
+            <CarouselWrap :onCardClick="handleCarouselClick" />
           </div>
 
           <!-- 로그인 유도 영역 -->
@@ -236,7 +236,7 @@
 
     <!-- 광장 커뮤니티  SlidePanel -->
     <SlidePanel :width="'510px'" :visible="isListPanelOpen" @close="isListPanelOpen = false">
-      <CommunityListPanel @close="handleListPanelClose" @openDetail="isListPanelOpen = true" />
+      <CommunityListPanel @close="handleListPanelClose" />
     </SlidePanel>
 
     <!-- 사이트 이용약관 -->
@@ -458,8 +458,12 @@ const handlePanelClose = () => {
 };
 
 const handleCarouselClick = (card) => {
-  console.log('카드 클릭됨!', card);
-  if (!auth.isLoggedIn) showLoginAlert.value = true;
+  if (!auth.isLoggedIn) {
+    showLoginAlert.value = true;
+  } else {
+    selectedArticleDetail.value = card;
+    isArticleDetailOpen.value = true;
+  }
 };
 
 const handleCommunityMove = () => {

--- a/src/components/carousel/CarouselWrap.vue
+++ b/src/components/carousel/CarouselWrap.vue
@@ -1,22 +1,42 @@
 <script setup>
-import { defineProps } from 'vue';
+import { defineProps, ref, onMounted } from 'vue';
 import 'vue3-carousel/carousel.css';
 import { Carousel, Slide } from 'vue3-carousel';
+import { getPopularBoards } from '@/api/boards';
 
-// 이미지 데이터 TODO
-const cards = Array.from({ length: 10 }, (_, index) => ({
-  id: index + 1,
-  url: `https://picsum.photos/seed/${Math.random()}/500/500`,
-  tag: '기억',
-  title:
-    '타이틀 두줄 이상일 때, 타이틀 두줄 이상 세줄이 상 아무튼긴 데이터 아무튼긴 데이터 아무튼긴 데이터',
-  contents:
-    '컨텐츠 한줄이상일 떄 이클립시스 컨텐츠 한줄이상일 떄 이클립시스 컨텐츠 한줄이상일 떄 이클립시스 컨텐츠 한줄이상일 떄 이클립시스',
-  user: '검은 태양의 핀 글자 글자 글자 글자 최대25',
-  data: '2025-05-05 PM 8:00',
-  count: 999,
-  likes: 999,
-}));
+const cards = ref([]);
+const loading = ref(false);
+
+const loadPopularBoards = async () => {
+  try {
+    loading.value = true;
+    const response = await getPopularBoards(5);
+    if (response && response.data) {
+      cards.value = response.data.map(board => ({
+        id: board.id,
+        boardId: board.id,
+        url: board.imageUrl || "",
+        category: board.category || '기본',
+        title: board.title,
+        content: board.content || '',
+        authorNickname: board.nickname || '익명',
+        createdAt: board.createdAt,
+        viewCount: board.viewCount || 0,
+        likeCount: board.likeCount || 0,
+        commentCount: board.commentCount || 0,
+      }));
+    }
+  } catch (error) {
+    console.error('인기 게시글 로딩 실패:', error);
+    cards.value = [];
+  } finally {
+    loading.value = false;
+  }
+};
+
+onMounted(() => {
+  loadPopularBoards();
+});
 
 const props = defineProps({
   itemsToShow: { type: Number, default: 1.2 },
@@ -43,27 +63,16 @@ const carouselConfig = {
 </script>
 
 <template>
-  <Carousel v-bind="carouselConfig">
+  <Carousel v-bind="carouselConfig" v-if="!loading">
     <Slide v-for="card in cards" :key="card.id">
-      <div
-        class="slide_wrap"
-        :class="{ green: props.green }"
-        @click="props.onCardClick && props.onCardClick(card)"
-      >
+      <div class="slide_wrap" :class="{ green: props.green }" @click="props.onCardClick && props.onCardClick(card)">
         <div class="slide_card">
           <span class="slide_card_tag">{{ card.tag }}</span>
           <span class="slide_card_arrow">
-            <img
-              :src="
-                props.green
-                  ? require('@/assets/slideCardArrowGreen.svg')
-                  : require('@/assets/slideCardArrow.svg')
-              "
-              class="card_arrow_icon"
-              alt="card arrow icon"
-              width="18"
-              height="18"
-            />
+            <img :src="props.green
+              ? require('@/assets/slideCardArrowGreen.svg')
+              : require('@/assets/slideCardArrow.svg')
+              " class="card_arrow_icon" alt="card arrow icon" width="18" height="18" />
           </span>
         </div>
         <div class="slide_card">
@@ -72,26 +81,19 @@ const carouselConfig = {
             <span class="ellipsis__1 contents_detail">{{ card.contents }}</span>
           </span>
           <span class="slide_card_contents img_wrap">
-            <img :src="card.url" alt="card" />
+            <img v-if="card.url" :src="card.url" alt="card" />
           </span>
         </div>
         <div class="slide_card lines">
           <span class="ellipsis__2 card_bottom_text user">{{ card.user }}</span>
           <span class="card_bottom_text data">{{ card.data }}</span>
-          <span class="card_bottom_text count">조회수 {{ card.count }}</span>
+          <span class="card_bottom_text count">조회수 {{ card.viewCount }}</span>
           <button class="card_bottom_button card_bottom_text">
-            <span> {{ card.likes }}</span>
-            <img
-              :src="
-                props.green
-                  ? require('@/assets/heartButtonIconGreen.svg')
-                  : require('@/assets/heartButtonIcon.svg')
-              "
-              class="like__toggle"
-              alt="like toggle icon"
-              width="16"
-              height="16"
-            />
+            <span> {{ card.likeCount }}</span>
+            <img :src="props.green
+              ? require('@/assets/heartButtonIconGreen.svg')
+              : require('@/assets/heartButtonIcon.svg')
+              " class="like__toggle" alt="like toggle icon" width="16" height="16" />
           </button>
         </div>
       </div>
@@ -114,6 +116,7 @@ const carouselConfig = {
   padding: 15px;
   cursor: pointer;
 }
+
 .slide_card {
   display: flex;
   flex-direction: row;
@@ -121,6 +124,7 @@ const carouselConfig = {
   justify-content: space-between;
   padding-bottom: 10px;
 }
+
 .slide_card_tag {
   display: flex;
   align-items: center;
@@ -135,39 +139,47 @@ const carouselConfig = {
   font-size: 12px;
   letter-spacing: -0.5px;
 }
+
 .slide_card_arrow {
   display: flex;
   align-items: center;
   justify-content: center;
 }
+
 .slide_card_contents {
   display: flex;
 }
+
 .text_wrap {
   width: calc(100% - 80px);
   display: flex;
   flex-direction: column;
 }
+
 .contents_title {
   font-weight: 700;
   font-size: 16px;
   line-height: 140%;
   letter-spacing: -0.5px;
 }
+
 .contents_detail {
   font-weight: 400;
   font-size: 12px;
   padding-top: 8px;
 }
+
 .img_wrap {
   width: 68px;
   height: 68px;
   border-radius: 8px;
   overflow: hidden;
 }
+
 .slide_card.lines {
   position: relative;
 }
+
 .slide_card.lines::after {
   content: '';
   display: flex;
@@ -179,6 +191,7 @@ const carouselConfig = {
   right: 0;
   left: -14px;
 }
+
 .card_bottom_text {
   color: #f1cfc8;
   font-family: 'Roboto';
@@ -198,15 +211,19 @@ const carouselConfig = {
   padding: 4px 0;
   padding-right: 4px;
 }
+
 .card_bottom_text.user {
   width: 55px;
 }
+
 .card_bottom_text.data {
   min-width: 105px;
 }
+
 .card_bottom_text.count {
   min-width: 55px;
 }
+
 .card_bottom_button {
   display: flex;
   flex-direction: row-reverse;
@@ -221,9 +238,11 @@ const carouselConfig = {
   background-color: #01523e;
   border: 1px solid #00ffc2;
 }
+
 .slide_wrap.green .card_bottom_text {
   color: #00ffc2;
 }
+
 .slide_wrap.green .slide_card_tag {
   border: 1px solid #00ffc2;
   color: #00ffc2;

--- a/src/components/communityPanel/CommunityListDetailPanel.vue
+++ b/src/components/communityPanel/CommunityListDetailPanel.vue
@@ -3,7 +3,6 @@
     <button class="slider_colse_button" @click="$emit('close')">
       <img src="@/assets/detailCloseArrow.svg" alt="slider close icon" width="36" height="36" />
     </button>
-
     <strong class="detail_title">{{ props.article?.title }}</strong>
 
     <div class="profile_img_wrap">
@@ -152,7 +151,6 @@ const formatTime = (dateString) => {
   return new Date(dateString).toLocaleTimeString('ko-KR', { hour: 'numeric', minute: '2-digit', hour12: true });
 };
 
-// 상태
 const comment = ref('');
 const showDeletePopup = ref(false);
 const showLikePopup = ref(false);
@@ -196,7 +194,6 @@ const handleBoardLike = async () => {
 };
 
 const handleCommentLike = async (commentId) => {
-  console.log('handleCommentLike', commentId);
   try {
     const response = await likeComment(commentId);
     if (response?.data) {
@@ -273,12 +270,10 @@ const deleteComment = (id) => {
   showDeletePopup.value = true;
 };
 
-// 페이지네이션
 const paginatedComments = computed(() => {
   const start = (commentsPage.value - 1) * commentsPerPage;
   return comments.value.slice(start, start + commentsPerPage);
 });
-console.log(paginatedComments, 'paginatedComments');
 const commentsTotalPages = computed(() => Math.ceil(comments.value.length / commentsPerPage));
 
 const changeCommentPage = (page) => {

--- a/src/components/communityPopup/CommunityWriteForm.vue
+++ b/src/components/communityPopup/CommunityWriteForm.vue
@@ -73,8 +73,14 @@ const submitPost = async () => {
 
     const response = await createBoard(formData);
 
-    showSuccessAlert.value = true;
+    title.value = '';
+    content.value = '';
+    imageFile.value = null;
+    previewUrl.value = '';
+    selectedCategory.value = categories[0];
+
     emit('submit', response.data);
+    emit('close');
 
   } catch (error) {
     console.error('게시글 작성 실패:', {
@@ -95,9 +101,11 @@ const submitPost = async () => {
   display: flex;
   flex-direction: column;
 }
-.form_wrap > *:first-child {
+
+.form_wrap>*:first-child {
   margin-bottom: 16px;
 }
+
 .input_title,
 .input_content {
   width: 100%;
@@ -107,10 +115,12 @@ const submitPost = async () => {
   border: none;
   font-size: 14px;
 }
+
 .input_content {
   height: 120px;
   resize: none;
 }
+
 .submit_button {
   background: black;
   color: white;


### PR DESCRIPTION
### API 연동
- 최신 게시글 목록 조회 (`getRecentBoards`) 연동
- 인기 게시글 캐러셀 (`getPopularBoards`) 연동
- 게시글 카테고리 필터링 기능 구현
- 게시글 클릭 시 상세 패널 자동 오픈

### 글쓰기/신고 기능 개선
- 글쓰기 완료 후 자동 폼 닫기

### UI/UX 개선
- 게시글 제목 2줄 표시 지원 (`word-break` 추가)
- 통계 정보 우측 정렬로 일관된 레이아웃 구현
- 변수명 개선 (`isPanel2depsOpen` → `isDetailPanelOpen`)