### PR TITLE
fix: 뉴스 정렬 로직 삭제

### DIFF
--- a/src/store/newsListStore.js
+++ b/src/store/newsListStore.js
@@ -30,7 +30,7 @@ export const useNewsListStore = defineStore('newsListStore', () => {
     loading.value = true;
     try {
       const raw = await articlesApi.getArticles();
-      articles.value = Array.isArray(raw) ? [...raw].reverse() : raw;
+      articles.value = raw;
       articles.value.forEach((article) => {
         if (article.category === '') article.category = '기타';
       });
@@ -52,7 +52,7 @@ export const useNewsListStore = defineStore('newsListStore', () => {
     loading.value = true;
     try {
       const raw = await articlesApi.getArticlesBySido(sido);
-      filteredArticles.value = Array.isArray(raw) ? [...raw].reverse() : raw;
+      filteredArticles.value = raw;
     } catch (error) {
       console.error('시도별 기사 로딩 실패:', error);
       filteredArticles.value = [];


### PR DESCRIPTION
- API 반환 순서 그대로 노출